### PR TITLE
split profile name of account name and permission set name by slash

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,8 +133,8 @@ func listSSOProfiles(ssoSession CacheFile) ([]Profile, error) {
 }
 
 func profileName(accountName, roleName string) string {
-	combined := fmt.Sprintf("%s-%s", accountName, roleName)
-	return strings.ToLower(regexp.MustCompile("[^a-zA-Z0-9-]").ReplaceAllString(combined, "-"))
+	combined := fmt.Sprintf("%s/%s", strings.TrimSpace(accountName), strings.TrimSpace(roleName))
+	return strings.ToLower(regexp.MustCompile("[^a-zA-Z0-9-/]").ReplaceAllString(combined, "-"))
 }
 
 type Profile struct {

--- a/main_test.go
+++ b/main_test.go
@@ -19,9 +19,9 @@ func Test_profileName(t *testing.T) {
 		args args
 		want string
 	}{
-		{name: "HappyCase", args: args{accountName: "app-account", roleName: "admin-profile"}, want: "app-account-admin-profile"},
-		{name: "CapsToLowercase", args: args{accountName: "App-Account", roleName: "aDmin-profile"}, want: "app-account-admin-profile"},
-		{name: "ReplaceChars", args: args{accountName: "app account/2", roleName: " admin-profile"}, want: "app-account-2--admin-profile"},
+		{name: "HappyCase", args: args{accountName: "app-account", roleName: "admin-profile"}, want: "app-account/admin-profile"},
+		{name: "CapsToLowercase", args: args{accountName: "App-Account", roleName: "aDmin-profile"}, want: "app-account/admin-profile"},
+		{name: "ReplaceChars", args: args{accountName: "app account.2", roleName: " admin-profile"}, want: "app-account-2/admin-profile"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Intention of making it easier to read the profile name when running eg. fzf.

```
accountname/permissionset-name
```